### PR TITLE
feature(light-tools): Add CSV List Of Tools For Lights

### DIFF
--- a/00 Main/gamedata/scripts/ui_furniture_light.script
+++ b/00 Main/gamedata/scripts/ui_furniture_light.script
@@ -153,25 +153,43 @@ function UIFurnitureLight:Close()
 end
 
 -------
+
 function toggle_light(obj_id)
 	local section = alife_object(obj_id):section_name()
 	local is_on = hf_obj_manager.get_data(obj_id).is_on
 	if is_on then
 		hf_obj_manager.update_data(obj_id, {is_on=false})
-	else
-		local req_matches = ini_sys:r_bool_ex(section, "require_matches") or false
-		if req_matches then
-			local obj_item = db.actor:object("matches") or db.actor:object("box_matches")
-			if obj_item then
-				utils_item.discharge(obj_item)
-				hf_obj_manager.update_data(obj_id, {is_on=true})
+		return
+	end
+
+	local required_tools = parse_list(ini_sys, section, "require_tool")
+
+	-- Check for legacy config key (backwards compatibility)
+	local require_matches = ini_sys:r_bool_ex(section, "require_matches") or false
+	if require_matches then
+		table.insert(required_tools, "matches")
+		table.insert(required_tools, "box_matches")
+	end
+
+	if is_empty(required_tools) then
+		hf_obj_manager.update_data(obj_id, {is_on=true})
+		return
+	end
+
+	for _,tool in pairs(required_tools) do
+		local obj_item = db.actor:object(tool)
+		if obj_item then
+			if utils_item.is_degradable(obj_item) then
+				utils_item.degrade(obj_item, 0.05)
 			else
-				actor_menu.set_msg(1, game.translate_string("st_ui_campfire_prereq"),3)
+				utils_item.discharge(obj_item)
 			end
-		else
 			hf_obj_manager.update_data(obj_id, {is_on=true})
+			return
 		end
 	end
+
+	actor_menu.set_msg(1, game.translate_string("st_ui_campfire_prereq"), 3)
 end
 
 function start_dialog(obj_id)

--- a/10 Nomad Module/12 Portable Lights/gamedata/configs/items/items/items_hf_nomad_lights.ltx
+++ b/10 Nomad Module/12 Portable Lights/gamedata/configs/items/items/items_hf_nomad_lights.ltx
@@ -126,7 +126,7 @@ fuel_section                             = kerosene
 item_section                             = device_gas_lamp
 light_section                            = definition_gas_lamp
 placeable_type                           = light
-require_matches                          = true
+require_tool                             = matches, box_matches
 
 base_rotation                            = -90
 bounding_box_size                        = 0.148134, 0.187031, 0.167756


### PR DESCRIPTION
This MR adds the ability to define viable tools to light up Hideout Furniture's lights, as opposed to them being hard-coded in `ui_furniture_light.script`.

Now, it is possible to define tools in a light config the following way :
```INI
[my_light_config]
require_tool                             = matches, box_matches
```

It is also possible to externally add new tools to the list, with DLTX :
```INI
![someone_elses_light_config]
>require_tool                           = my_first_tool, my_second_tool
```

Given we do not know the type of tool that will be used, the script now checks if the item is degradable, and will degrade or discharge the tool accordingly.

To ensure backwards compatibility, if the old key `require_matches` is found, `matches` and `box_matches` are forcefully added to the list of required tools. There is a chance for this to make it so a tool is listed twice, but this is benign and will not cause issues.